### PR TITLE
feat: add transport dropdown to mission menu

### DIFF
--- a/test/swap_card_test/main.py
+++ b/test/swap_card_test/main.py
@@ -5,11 +5,12 @@ from kivy.clock import Clock
 from kivy.core.window import Window
 from kivy.lang import Builder
 from kivy.metrics import dp
-from kivy.properties import BooleanProperty, NumericProperty, StringProperty
+from kivy.properties import BooleanProperty, NumericProperty, StringProperty, ObjectProperty
 from kivy.uix.widget import Widget
 
 from kivymd.app import MDApp
 from kivymd.uix.segmentedbutton import MDSegmentedButton
+from kivymd.uix.menu import MDDropdownMenu
 
 
 class StretchSegmentedButton(MDSegmentedButton):
@@ -29,6 +30,8 @@ class CollapsibleMenuController(Widget):
     """Сворачиваемая карточка с drag по «ручке» и клиппингом контента."""
 
     title = StringProperty("Управление миссией БПЛА")
+    transport = StringProperty("БПЛА-1")
+    _transport_menu = ObjectProperty(None)
 
     # авто 1↔2 столбца
     cols = NumericProperty(1)
@@ -143,6 +146,28 @@ class CollapsibleMenuController(Widget):
 
     def on_segment_pressed(self, _key: str):
         self.expand()
+
+    def open_transport_menu(self, caller):
+        app = MDApp.get_running_app()
+        menu_items = []
+        for name in ["БПЛА-1", "БПЛА-2", "БПЛА-3"]:
+            selected = name == self.transport
+            menu_items.append(
+                {
+                    "text": name,
+                    "leading_icon": "check" if selected else "",
+                    "text_color": app.theme_cls.primaryColor if selected else None,
+                    "leading_icon_color": app.theme_cls.primaryColor if selected else None,
+                    "on_release": lambda x=name: self.set_transport(x),
+                }
+            )
+        self._transport_menu = MDDropdownMenu(caller=caller, items=menu_items)
+        self._transport_menu.open()
+
+    def set_transport(self, name):
+        self.transport = name
+        if self._transport_menu:
+            self._transport_menu.dismiss()
 
     def animate_to(self, target: float, duration: float = 0.22):
         Animation.cancel_all(self, "slide")

--- a/test/swap_card_test/menu.kv
+++ b/test/swap_card_test/menu.kv
@@ -41,6 +41,19 @@
         valign: "middle"
         halign: "left"
 
+    MDDropDownItem:
+        id: transport_item
+        on_release: root.controller.open_transport_menu(self) if root.controller else None
+        pos_hint: {"center_y": .5}
+        md_bg_color: app.theme_cls.surfaceContainerColor
+        radius: dp(8)
+
+        MDDropDownItemText:
+            text: root.controller.transport if root.controller else ""
+            role: "medium"
+            theme_text_color: "Custom"
+            text_color: app.theme_cls.onSurfaceColor
+
     MDBoxLayout:
         adaptive_size: True
         spacing: dp(8)


### PR DESCRIPTION
## Summary
- add transport selection dropdown to mission menu header
- support updating displayed transport via MDDropdownMenu
- highlight current transport with check icon and color

## Testing
- `timeout 5s .venv/bin/python test/swap_card_test/main.py` *(fails: Unable to get a Window, abort)*

------
https://chatgpt.com/codex/tasks/task_e_68b1caf5f6e48324b56c4f881a9af6e8